### PR TITLE
ログファイルの出力先をホームディレクトリ配下.text-clipperに配置するようにした

### DIFF
--- a/common/path.go
+++ b/common/path.go
@@ -1,0 +1,17 @@
+package common
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+func GetPathFromDefaultPath(fileName string) (string, error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("unable to find home directory: %w", err)
+	}
+	defaultPath := filepath.Join(homeDir, ".text-clipper", fileName)
+
+	return defaultPath, nil
+}

--- a/text-clipper.go
+++ b/text-clipper.go
@@ -20,14 +20,12 @@ var (
 func openSqlite() (*gorm.DB, error) {
 
 	// デフォルトのデータベースパス
-	homeDir, err := os.UserHomeDir()
+	defaultDBPath, err := common.GetPathFromDefaultPath("text-clipper.db")
 	if err != nil {
-		return nil, fmt.Errorf("unable to find home directory: %w", err)
+		return nil, fmt.Errorf("failed in getting db path: %w", err)
 	}
-	defaultDBPath := filepath.Join(homeDir, ".text-clipper", "text-clipper.db")
-
 	// 環境変数で指定されたパスがあればそれを使用
-	dbPath := os.Getenv("TEXT_CLIPPER_DB_PATH")
+	dbPath := os.Getenv("TEXT_CLIPPER__DB_PATH")
 	if dbPath == "" {
 		dbPath = defaultDBPath
 	}
@@ -74,6 +72,7 @@ func main() {
 	db, err := openSqlite()
 	if err != nil {
 		log.Fatal(err)
+		os.Exit(1)
 	}
 	tr := text.GormRepository{DB: db}
 	tui.StartTea(tr)

--- a/tui/tui.go
+++ b/tui/tui.go
@@ -5,15 +5,29 @@ import (
 	"os"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/o-kaisan/text-clipper/common"
 	"github.com/o-kaisan/text-clipper/text"
 	"github.com/o-kaisan/text-clipper/tui/constants"
 )
 
 // StartTea the entry point for the UI. Initializes the model.
 func StartTea(tr text.GormRepository) error {
-	f, err := tea.LogToFile("debug.log", "debug")
+	// デフォルトのデータベースパス
+	defaultLogFilePath, err := common.GetPathFromDefaultPath("debug.log")
 	if err != nil {
-		log.Fatal("err: %w", err)
+		log.Fatal("failed in getting log file path: %w", err)
+		os.Exit(1)
+	}
+	// 環境変数で指定されたパスがあればそれを使用
+	logFilePath := os.Getenv("TEXT_CLIPPER__LOG_FILE_PATH")
+	if defaultLogFilePath == "" {
+		defaultLogFilePath = logFilePath
+	}
+
+	f, err := tea.LogToFile(defaultLogFilePath, "debug")
+	if err != nil {
+		log.Fatal("failed in setting log file: %w", err)
+		os.Exit(1)
 	}
 	defer f.Close()
 


### PR DESCRIPTION
#9 を修正した